### PR TITLE
Update to latest dependencies + minSdk 14 + cleanup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.1'
     defaultConfig {
         applicationId "com.example.slideup"
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
 
@@ -24,7 +24,7 @@ android {
 }
 
 dependencies {
-    compile "com.android.support:appcompat-v7:${versions.support}"
-    compile "com.android.support:design:${versions.support}"
-    compile project(path: ':library')
+    implementation "com.android.support:appcompat-v7:${versions.support}"
+    implementation "com.android.support:design:${versions.support}"
+    implementation project(path: ':library')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         versions = [
-                support        : '25.4.0',
+                support        : '27.0.1',
                 SlideUp        : '2.2.1',
                 Rx             : [
                         Java     : '1.3.0'
@@ -9,12 +9,12 @@ buildscript {
         ]
     }
     repositories {
+        google()
         mavenCentral()
         jcenter()
-        maven { url 'https://maven.google.com' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue May 30 17:07:46 MSK 2017
+#Thu Oct 05 10:36:33 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-milestone-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.1'
 
     defaultConfig {
-        minSdkVersion 12
-        targetSdkVersion 25
+        minSdkVersion 14
+        targetSdkVersion 27
         versionCode 8
         versionName "2.2.7.1"
     }
@@ -27,8 +27,7 @@ android {
 }
 
 dependencies {
-    compile "com.android.support:support-annotations:${versions.support}"
-    compile "com.android.support:appcompat-v7:${versions.support}"
+    implementation "com.android.support:support-annotations:${versions.support}"
 }
 
 task androidJavadocs(type: Javadoc) {


### PR DESCRIPTION
* Update to API 27
* Update Android Studio to 3.0.1
* Remove unnecessary dependency of com.android.support:appcompat-v7 in library momdule
* Need to update minSdk version from 12 to 14 (see below)

From https://developer.android.com/topic/libraries/support-library/index.html (retrieved 11/29/2017)

> Caution: Starting with Support Library release 26.0.0 (July 2017), the minimum supported API level across most support libraries has increased to Android 4.0 (API level 14) for most library packages. For more information, see Version Support and Package Names in this document.