### PR TITLE
Add capability to trigger SlideUp (up/down/start/end) from another View

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Create a SlideUp object and pass in your view
 slideUp = new SlideUpBuilder(slideView)
                 .withStartState(SlideUp.State.HIDDEN)
                 .withStartGravity(Gravity.BOTTOM)
-                
+
+                //.withSlideFromOtherView(anotherView)
                 //.withGesturesEnabled()
                 //.withHideSoftInputWhenDisplayed()
                 //.withInterpolator()
@@ -74,6 +75,7 @@ slideUp = new SlideUpBuilder(slideView)
 # Advanced example
 [SlideUpViewActivity.java](https://github.com/mancj/SlideUp-Android/blob/master/app/src/main/java/com/example/slideup/SlideUpViewActivity.java)
 ```java
+rootView = findViewById(R.id.rootView);
 slideView = findViewById(R.id.slideView);
 dim = findViewById(R.id.dim);
 fab = (FloatingActionButton) findViewById(R.id.fab);
@@ -84,6 +86,10 @@ slideUp = new SlideUpBuilder(slideView)
              @Override
              public void onSlide(float percent) {
                  dim.setAlpha(1 - (percent / 100));
+                 if (percent < 100) {
+                    // slideUp started showing
+                    fab.hide()
+                 }
              }
 
              @Override
@@ -96,13 +102,13 @@ slideUp = new SlideUpBuilder(slideView)
          .withStartGravity(Gravity.TOP)
          .withLoggingEnabled(true)
          .withStartState(SlideUp.State.HIDDEN)
+         .withSlideFromOtherView(rootView)
          .build();
 
 fab.setOnClickListener(new View.OnClickListener() {
     @Override
     public void onClick(View view) {
         slideUp.show();
-        fab.hide();
     }
 });
 ```

--- a/app/src/main/java/com/example/slideup/SlideEndViewActivity.java
+++ b/app/src/main/java/com/example/slideup/SlideEndViewActivity.java
@@ -59,6 +59,7 @@ public class SlideEndViewActivity extends AppCompatActivity {
                 .withStartGravity(Gravity.END)
                 .withLoggingEnabled(true)
                 .withStartState(SlideUp.State.HIDDEN)
+                .withSlideFromOtherView(findViewById(R.id.rootView))
                 .build();
 
         fab.setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/java/com/example/slideup/SlideUpViewActivity.java
+++ b/app/src/main/java/com/example/slideup/SlideUpViewActivity.java
@@ -47,6 +47,9 @@ public class SlideUpViewActivity extends AppCompatActivity {
                     @Override
                     public void onSlide(float percent) {
                         dim.setAlpha(1 - (percent / 100));
+                        if (fab.isShown() && percent < 100) {
+                            fab.hide();
+                        }
                     }
 
                     @Override
@@ -60,13 +63,13 @@ public class SlideUpViewActivity extends AppCompatActivity {
                 .withLoggingEnabled(true)
                 .withGesturesEnabled(true)
                 .withStartState(SlideUp.State.HIDDEN)
+                .withSlideFromOtherView(findViewById(R.id.rootView))
                 .build();
 
         fab.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 slideUp.show();
-                fab.hide();
             }
         });
 

--- a/app/src/main/res/layout/activity_slide_end_view.xml
+++ b/app/src/main/res/layout/activity_slide_end_view.xml
@@ -17,6 +17,7 @@
         android:background="@color/dimBg" />
 
     <android.support.design.widget.CoordinatorLayout
+        android:id="@+id/rootView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context="com.example.slideup.SlideDownViewActivity">

--- a/app/src/main/res/layout/activity_slide_up_view.xml
+++ b/app/src/main/res/layout/activity_slide_up_view.xml
@@ -17,6 +17,7 @@
         android:background="@color/dimBg" />
 
     <android.support.design.widget.CoordinatorLayout
+        android:id="@+id/rootView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context="com.example.slideup.SlideUpViewActivity">
@@ -37,7 +38,8 @@
 
             </android.support.design.widget.AppBarLayout>
 
-            <include layout="@layout/content_slide_up_view" />
+            <include layout="@layout/content_slide_up_view"
+              tools:visibility = "gone"/>
 
             <android.support.design.widget.FloatingActionButton
                 android:id="@+id/fab"

--- a/library/src/main/java/com/mancj/slideup/AbstractSlideTranslator.java
+++ b/library/src/main/java/com/mancj/slideup/AbstractSlideTranslator.java
@@ -1,0 +1,46 @@
+package com.mancj.slideup;
+
+public abstract class AbstractSlideTranslator {
+  protected final SlideUpBuilder mBuilder;
+  protected final AnimationProcessor mAnimationProcessor;
+
+  public AbstractSlideTranslator(SlideUpBuilder builder, AnimationProcessor animationProcessor) {
+    this.mBuilder = builder;
+    this.mAnimationProcessor = animationProcessor;
+  }
+
+  public void setTranslationY(float translationY) {
+    mBuilder.mSliderView.setTranslationY(translationY);
+  }
+
+  public void setTranslationX(float translationX) {
+    mBuilder.mSliderView.setTranslationX(translationX);
+  }
+
+  public final void showSlideView(boolean immediately) {
+    mAnimationProcessor.endAnimation();
+    if (immediately) {
+      immediatelyShowSlideView();
+    } else {
+      animateShowSlideView();
+    }
+  }
+
+  public final void hideSlideView(boolean immediately) {
+    mAnimationProcessor.endAnimation();
+    if (immediately) {
+      immediatelyHideSlideView();
+    } else {
+      animateHideSlideView();
+    }
+  }
+
+  protected abstract void immediatelyShowSlideView();
+
+  protected abstract void animateShowSlideView();
+
+  protected abstract void immediatelyHideSlideView();
+
+  protected abstract void animateHideSlideView();
+
+}

--- a/library/src/main/java/com/mancj/slideup/BottomToTopSlideTranslator.java
+++ b/library/src/main/java/com/mancj/slideup/BottomToTopSlideTranslator.java
@@ -1,0 +1,39 @@
+package com.mancj.slideup;
+
+
+import static com.mancj.slideup.SlideUp.State.HIDDEN;
+import static com.mancj.slideup.SlideUp.State.SHOWED;
+
+public class BottomToTopSlideTranslator extends AbstractSlideTranslator {
+  public BottomToTopSlideTranslator(SlideUpBuilder builder, AnimationProcessor animationProcessor) {
+    super(builder, animationProcessor);
+  }
+
+  @Override
+  protected void immediatelyShowSlideView() {
+    if (mBuilder.mSliderView.getHeight() > 0) {
+      mBuilder.mSliderView.setTranslationY(0);
+    } else {
+      mBuilder.mStartState = SHOWED;
+    }
+  }
+
+  @Override
+  protected void animateShowSlideView() {
+    mAnimationProcessor.setValuesAndStart(mBuilder.mSliderView.getTranslationY(), 0);
+  }
+
+  @Override
+  protected void immediatelyHideSlideView() {
+    if (mBuilder.mSliderView.getHeight() > 0) {
+      mBuilder.mSliderView.setTranslationY(mBuilder.mSliderView.getHeight());
+    } else {
+      mBuilder.mStartState = HIDDEN;
+    }
+  }
+
+  @Override
+  protected void animateHideSlideView() {
+    mAnimationProcessor.setValuesAndStart(mBuilder.mSliderView.getTranslationY(), mBuilder.mSliderView.getHeight());
+  }
+}

--- a/library/src/main/java/com/mancj/slideup/EndToStartSlideTranslator.java
+++ b/library/src/main/java/com/mancj/slideup/EndToStartSlideTranslator.java
@@ -1,0 +1,38 @@
+package com.mancj.slideup;
+
+import static com.mancj.slideup.SlideUp.State.HIDDEN;
+import static com.mancj.slideup.SlideUp.State.SHOWED;
+
+public class EndToStartSlideTranslator extends AbstractSlideTranslator {
+  public EndToStartSlideTranslator(SlideUpBuilder builder, AnimationProcessor animationProcessor) {
+    super(builder, animationProcessor);
+  }
+
+  @Override
+  protected void immediatelyShowSlideView() {
+    if (mBuilder.mSliderView.getWidth() > 0) {
+      mBuilder.mSliderView.setTranslationX(0);
+    } else {
+      mBuilder.mStartState = SHOWED;
+    }
+  }
+
+  @Override
+  protected void animateShowSlideView() {
+    mAnimationProcessor.setValuesAndStart(mBuilder.mSliderView.getTranslationX(), 0);
+  }
+
+  @Override
+  protected void immediatelyHideSlideView() {
+    if (mBuilder.mSliderView.getWidth() > 0) {
+      mBuilder.mSliderView.setTranslationX(mBuilder.mSliderView.getWidth());
+    } else {
+      mBuilder.mStartState = HIDDEN;
+    }
+  }
+
+  @Override
+  protected void animateHideSlideView() {
+    mAnimationProcessor.setValuesAndStart(mBuilder.mSliderView.getTranslationX(), mBuilder.mSliderView.getWidth());
+  }
+}

--- a/library/src/main/java/com/mancj/slideup/HorizontalTouchConsumer.java
+++ b/library/src/main/java/com/mancj/slideup/HorizontalTouchConsumer.java
@@ -10,8 +10,8 @@ class HorizontalTouchConsumer extends TouchConsumer {
     private boolean mGoingToStart = false;
     private boolean mGoingToEnd = false;
     
-    HorizontalTouchConsumer(SlideUpBuilder builder, PercentageChangeCalculator percentageChangeCalculator, AnimationProcessor animationProcessor) {
-        super(builder, percentageChangeCalculator, animationProcessor);
+    HorizontalTouchConsumer(SlideUpBuilder builder, PercentageChangeCalculator percentageChangeCalculator, AbstractSlideTranslator translator) {
+        super(builder, percentageChangeCalculator, translator);
     }
     
     boolean consumeEndToStart(View touchedView, MotionEvent event){
@@ -27,7 +27,6 @@ class HorizontalTouchConsumer extends TouchConsumer {
             case MotionEvent.ACTION_MOVE:
                 float difference = event.getRawX() - mStartPositionX;
                 float moveTo = mViewStartPositionX + difference;
-                float percents = moveTo * 100 / mBuilder.mSliderView.getWidth();
                 calculateDirection(event);
                 
                 if (moveTo > 0 && mCanSlide){
@@ -43,9 +42,9 @@ class HorizontalTouchConsumer extends TouchConsumer {
                 boolean scrollableAreaConsumed = mBuilder.mSliderView.getTranslationX() > mBuilder.mSliderView.getWidth() / 5;
                 
                 if (scrollableAreaConsumed && mGoingToEnd){
-                    mAnimationProcessor.setValuesAndStart(slideAnimationFrom, mBuilder.mSliderView.getWidth());
+                    mTranslator.hideSlideView(false);
                 }else {
-                    mAnimationProcessor.setValuesAndStart(slideAnimationFrom, 0);
+                    mTranslator.showSlideView(false);
                 }
                 mCanSlide = true;
                 break;
@@ -68,7 +67,6 @@ class HorizontalTouchConsumer extends TouchConsumer {
             case MotionEvent.ACTION_MOVE:
                 float difference = event.getRawX() - mStartPositionX;
                 float moveTo = mViewStartPositionX + difference;
-                float percents = moveTo * 100 / -mBuilder.mSliderView.getWidth();
                 calculateDirection(event);
                 
                 if (moveTo < 0 && mCanSlide){
@@ -84,9 +82,9 @@ class HorizontalTouchConsumer extends TouchConsumer {
                 boolean scrollableAreaConsumed = mBuilder.mSliderView.getTranslationX() < -mBuilder.mSliderView.getHeight() / 5;
                 
                 if (scrollableAreaConsumed && mGoingToStart){
-                    mAnimationProcessor.setValuesAndStart(slideAnimationFrom, mBuilder.mSliderView.getWidth());
+                    mTranslator.hideSlideView(false);
                 }else {
-                    mAnimationProcessor.setValuesAndStart(slideAnimationFrom, 0);
+                    mTranslator.showSlideView(false);
                 }
                 mCanSlide = true;
                 break;

--- a/library/src/main/java/com/mancj/slideup/HorizontalTouchConsumer.java
+++ b/library/src/main/java/com/mancj/slideup/HorizontalTouchConsumer.java
@@ -10,8 +10,8 @@ class HorizontalTouchConsumer extends TouchConsumer {
     private boolean mGoingToStart = false;
     private boolean mGoingToEnd = false;
     
-    HorizontalTouchConsumer(SlideUpBuilder builder, LoggerNotifier notifier, AnimationProcessor animationProcessor) {
-        super(builder, notifier, animationProcessor);
+    HorizontalTouchConsumer(SlideUpBuilder builder, PercentageChangeCalculator percentageChangeCalculator, AnimationProcessor animationProcessor) {
+        super(builder, percentageChangeCalculator, animationProcessor);
     }
     
     boolean consumeEndToStart(View touchedView, MotionEvent event){
@@ -31,8 +31,8 @@ class HorizontalTouchConsumer extends TouchConsumer {
                 calculateDirection(event);
                 
                 if (moveTo > 0 && mCanSlide){
-                    mNotifier.notifyPercentChanged(percents);
                     mBuilder.mSliderView.setTranslationX(moveTo);
+                    mPercentageCalculator.recalculatePercentage();
                 }
                 break;
             case MotionEvent.ACTION_UP:
@@ -72,8 +72,8 @@ class HorizontalTouchConsumer extends TouchConsumer {
                 calculateDirection(event);
                 
                 if (moveTo < 0 && mCanSlide){
-                    mNotifier.notifyPercentChanged(percents);
                     mBuilder.mSliderView.setTranslationX(moveTo);
+                    mPercentageCalculator.recalculatePercentage();
                 }
                 break;
             case MotionEvent.ACTION_UP:

--- a/library/src/main/java/com/mancj/slideup/HorizontalTouchConsumer.java
+++ b/library/src/main/java/com/mancj/slideup/HorizontalTouchConsumer.java
@@ -1,36 +1,38 @@
 package com.mancj.slideup;
 
 import android.view.MotionEvent;
+import android.view.View;
 
 /**
  * @author pa.gulko zTrap (12.07.2017)
  */
 class HorizontalTouchConsumer extends TouchConsumer {
+    private boolean mGoingToStart = false;
+    private boolean mGoingToEnd = false;
     
     HorizontalTouchConsumer(SlideUpBuilder builder, LoggerNotifier notifier, AnimationProcessor animationProcessor) {
         super(builder, notifier, animationProcessor);
     }
     
-    boolean consumeEndToStart(MotionEvent event){
+    boolean consumeEndToStart(View touchedView, MotionEvent event){
         float touchedArea = event.getX();
         switch (event.getActionMasked()){
             case MotionEvent.ACTION_DOWN:
                 mViewWidth = mBuilder.mSliderView.getWidth();
                 mStartPositionX = event.getRawX();
                 mViewStartPositionX = mBuilder.mSliderView.getTranslationX();
-                mCanSlide = getStart() + mBuilder.mTouchableArea >= touchedArea;
+                mCanSlide = touchFromAlsoSlide(touchedView, event);
+                mCanSlide |= getStart() + mBuilder.mTouchableArea >= touchedArea;
                 break;
             case MotionEvent.ACTION_MOVE:
                 float difference = event.getRawX() - mStartPositionX;
                 float moveTo = mViewStartPositionX + difference;
                 float percents = moveTo * 100 / mBuilder.mSliderView.getWidth();
+                calculateDirection(event);
                 
                 if (moveTo > 0 && mCanSlide){
                     mNotifier.notifyPercentChanged(percents);
                     mBuilder.mSliderView.setTranslationX(moveTo);
-                }
-                if (event.getRawX() > mMaxSlidePosition) {
-                    mMaxSlidePosition = event.getRawX();
                 }
                 break;
             case MotionEvent.ACTION_UP:
@@ -38,42 +40,40 @@ class HorizontalTouchConsumer extends TouchConsumer {
                 if (slideAnimationFrom == mViewStartPositionX){
                     return !Internal.isUpEventInView(mBuilder.mSliderView, event);
                 }
-                boolean mustShow = mMaxSlidePosition > event.getRawX();
                 boolean scrollableAreaConsumed = mBuilder.mSliderView.getTranslationX() > mBuilder.mSliderView.getWidth() / 5;
                 
-                if (scrollableAreaConsumed && !mustShow){
+                if (scrollableAreaConsumed && mGoingToEnd){
                     mAnimationProcessor.setValuesAndStart(slideAnimationFrom, mBuilder.mSliderView.getWidth());
                 }else {
                     mAnimationProcessor.setValuesAndStart(slideAnimationFrom, 0);
                 }
                 mCanSlide = true;
-                mMaxSlidePosition = 0;
                 break;
         }
+        mPrevPositionY = event.getRawY();
+        mPrevPositionX = event.getRawX();
         return true;
     }
     
-    boolean consumeStartToEnd(MotionEvent event){
+    boolean consumeStartToEnd(View touchedView, MotionEvent event){
         float touchedArea = event.getX();
         switch (event.getActionMasked()){
             case MotionEvent.ACTION_DOWN:
-                mMaxSlidePosition = mViewWidth;
                 mViewWidth = mBuilder.mSliderView.getWidth();
                 mStartPositionX = event.getRawX();
                 mViewStartPositionX = mBuilder.mSliderView.getTranslationX();
-                mCanSlide = getEnd() - mBuilder.mTouchableArea >= touchedArea;
+                mCanSlide = touchFromAlsoSlide(touchedView, event);
+                mCanSlide |= getEnd() - mBuilder.mTouchableArea >= touchedArea;
                 break;
             case MotionEvent.ACTION_MOVE:
                 float difference = event.getRawX() - mStartPositionX;
                 float moveTo = mViewStartPositionX + difference;
                 float percents = moveTo * 100 / -mBuilder.mSliderView.getWidth();
+                calculateDirection(event);
                 
                 if (moveTo < 0 && mCanSlide){
                     mNotifier.notifyPercentChanged(percents);
                     mBuilder.mSliderView.setTranslationX(moveTo);
-                }
-                if (event.getRawX() < mMaxSlidePosition) {
-                    mMaxSlidePosition = event.getRawX();
                 }
                 break;
             case MotionEvent.ACTION_UP:
@@ -81,18 +81,23 @@ class HorizontalTouchConsumer extends TouchConsumer {
                 if (slideAnimationFrom == mViewStartPositionX){
                     return !Internal.isUpEventInView(mBuilder.mSliderView, event);
                 }
-                boolean mustShow = mMaxSlidePosition < event.getRawX();
                 boolean scrollableAreaConsumed = mBuilder.mSliderView.getTranslationX() < -mBuilder.mSliderView.getHeight() / 5;
                 
-                if (scrollableAreaConsumed && !mustShow){
+                if (scrollableAreaConsumed && mGoingToStart){
                     mAnimationProcessor.setValuesAndStart(slideAnimationFrom, mBuilder.mSliderView.getWidth());
                 }else {
                     mAnimationProcessor.setValuesAndStart(slideAnimationFrom, 0);
                 }
                 mCanSlide = true;
-                mMaxSlidePosition = 0;
                 break;
         }
+        mPrevPositionY = event.getRawY();
+        mPrevPositionX = event.getRawX();
         return true;
+    }
+
+    private void calculateDirection(MotionEvent event) {
+        mGoingToStart = mPrevPositionX - event.getRawX() > 0;
+        mGoingToEnd = mPrevPositionX - event.getRawX() < 0;
     }
 }

--- a/library/src/main/java/com/mancj/slideup/PercentageChangeCalculator.java
+++ b/library/src/main/java/com/mancj/slideup/PercentageChangeCalculator.java
@@ -1,0 +1,5 @@
+package com.mancj.slideup;
+
+public interface PercentageChangeCalculator {
+  float recalculatePercentage();
+}

--- a/library/src/main/java/com/mancj/slideup/SlideUp.java
+++ b/library/src/main/java/com/mancj/slideup/SlideUp.java
@@ -25,7 +25,7 @@ import static android.view.View.VISIBLE;
 import static com.mancj.slideup.SlideUp.State.HIDDEN;
 import static com.mancj.slideup.SlideUp.State.SHOWED;
 
-public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpdateListener, Animator.AnimatorListener, LoggerNotifier {
+public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpdateListener, Animator.AnimatorListener, LoggerNotifier, PercentageChangeCalculator {
     private final static String TAG = SlideUp.class.getSimpleName();
     
     final static String KEY_START_GRAVITY = TAG + "_start_gravity";
@@ -35,7 +35,7 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
     final static String KEY_AUTO_SLIDE_DURATION = TAG + "_auto_slide_duration";
     final static String KEY_HIDE_SOFT_INPUT = TAG + "_hide_soft_input";
     final static String KEY_STATE_SAVED = TAG + "_state_saved";
-    
+
     /**
      * <p>Available start states</p>
      */
@@ -136,29 +136,29 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
                 }));
         updateToCurrentState();
     }
-    
+
     private void setTouchableAreaHorizontal(){
         if (mBuilder.mTouchableArea == 0) {
             mBuilder.mTouchableArea = (float) Math.ceil(mViewWidth / 10);
         }
     }
-    
+
     private void setTouchableAreaVertical(){
         if (mBuilder.mTouchableArea == 0) {
             mBuilder.mTouchableArea = (float) Math.ceil(mViewHeight / 10);
         }
     }
-    
+
     private void createAnimation() {
         mAnimationProcessor = new AnimationProcessor(mBuilder, this, this);
     }
-    
+
     private void createConsumers() {
         createAnimation();
         mVerticalTouchConsumer = new VerticalTouchConsumer(mBuilder, this, mAnimationProcessor);
         mHorizontalTouchConsumer = new HorizontalTouchConsumer(mBuilder, this, mAnimationProcessor);
     }
-    
+
     private void updateToCurrentState() {
         switch (mBuilder.mStartState) {
             case HIDDEN:
@@ -169,7 +169,7 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
                 break;
         }
     }
-    
+
     //region public interface
     /**
      * <p>Trying hide soft input from window</p>
@@ -180,7 +180,7 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
         ((InputMethodManager) mBuilder.mSliderView.getContext().getSystemService(Context.INPUT_METHOD_SERVICE))
                 .hideSoftInputFromWindow(mBuilder.mSliderView.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
     }
-    
+
     /**
      * <p>Trying show soft input to window</p>
      *
@@ -190,7 +190,7 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
         ((InputMethodManager) mBuilder.mSliderView.getContext().getSystemService(Context.INPUT_METHOD_SERVICE))
                 .showSoftInput(mBuilder.mSliderView, 0);
     }
-    
+
     /**
      * <p>Returns the visibility status for this view.</p>
      *
@@ -199,28 +199,28 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
     public boolean isVisible() {
         return mBuilder.mSliderView.getVisibility() == VISIBLE;
     }
-    
+
     /**
      * <p>Add Listener which will be used in combination with this SlideUp</p>
      */
     public void addSlideListener(@NonNull Listener listener) {
         mBuilder.mListeners.add(listener);
     }
-    
+
     /**
      * <p>Remove Listener which was used in combination with this SlideUp</p>
      */
     public void removeSlideListener(@NonNull Listener listener) {
         mBuilder.mListeners.remove(listener);
     }
-    
+
     /**
      * <p>Returns typed view which was used as slider</p>
      */
     public <T extends View> T getSliderView() {
         return (T) mBuilder.mSliderView;
     }
-    
+
     /**
      * <p>Set duration of animation (whenever you use {@link #hide()} or {@link #show()} methods)</p>
      *
@@ -230,14 +230,14 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
         mBuilder.withAutoSlideDuration(autoSlideDuration);
         mAnimationProcessor.paramsChanged();
     }
-    
+
     /**
      * <p>Returns duration of animation (whenever you use {@link #hide()} or {@link #show()} methods)</p>
      */
     public float getAutoSlideDuration() {
         return mBuilder.mAutoSlideDuration;
     }
-    
+
     /**
      * <p>Set touchable area <b>(in dp)</b> for interaction</p>
      *
@@ -246,7 +246,7 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
     public void setTouchableAreaDp(float touchableArea) {
         mBuilder.withTouchableAreaDp(touchableArea);
     }
-    
+
     /**
      * <p>Set touchable area <b>(in px)</b> for interaction</p>
      *
@@ -255,21 +255,21 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
     public void setTouchableAreaPx(float touchableArea) {
         mBuilder.withTouchableAreaPx(touchableArea);
     }
-    
+
     /**
      * <p>Returns touchable area <b>(in dp)</b> for interaction</p>
      */
     public float getTouchableAreaDp() {
         return mBuilder.mTouchableArea / mBuilder.mDensity;
     }
-    
+
     /**
      * <p>Returns touchable area <b>(in px)</b> for interaction</p>
      */
     public float getTouchableAreaPx() {
         return mBuilder.mTouchableArea;
     }
-    
+
     /**
      * <p>Returns running status of animation</p>
      *
@@ -278,35 +278,35 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
     public boolean isAnimationRunning() {
         return mAnimationProcessor.isAnimationRunning();
     }
-    
+
     /**
      * <p>Show view with animation</p>
      */
     public void show() {
         show(false);
     }
-    
+
     /**
      * <p>Hide view with animation</p>
      */
     public void hide() {
         hide(false);
     }
-    
+
     /**
      * <p>Hide view without animation</p>
      */
     public void hideImmediately() {
         hide(true);
     }
-    
+
     /**
      * <p>Show view without animation</p>
      */
     public void showImmediately() {
         show(true);
     }
-    
+
     /**
      * <p>Turning on/off debug logging</p>
      *
@@ -315,14 +315,14 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
     public void setLoggingEnabled(boolean enabled) {
         mBuilder.withLoggingEnabled(enabled);
     }
-    
+
     /**
      * <p>Returns current status of debug logging</p>
      */
     public boolean isLoggingEnabled() {
         return mBuilder.mDebug;
     }
-    
+
     /**
      * <p>Turning on/off gestures</p>
      *
@@ -331,21 +331,21 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
     public void setGesturesEnabled(boolean enabled) {
         mBuilder.withGesturesEnabled(enabled);
     }
-    
+
     /**
      * <p>Returns current status of gestures</p>
      */
     public boolean isGesturesEnabled() {
         return mBuilder.mGesturesEnabled;
     }
-    
+
     /**
      * <p>Returns current interpolator</p>
      */
     public TimeInterpolator getInterpolator() {
         return mBuilder.mInterpolator;
     }
-    
+
     /**
      * <p>Returns gravity which used in combination with this SlideUp</p>
      */
@@ -353,7 +353,7 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
     public int getStartGravity() {
         return mBuilder.mStartGravity;
     }
-    
+
     /**
      * <p>Sets interpolator for animation (whenever you use {@link #hide()} or {@link #show()} methods)</p>
      *
@@ -363,14 +363,14 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
         mBuilder.withInterpolator(interpolator);
         mAnimationProcessor.paramsChanged();
     }
-    
+
     /**
      * <p>Returns current behavior of soft input</p>
      */
     public boolean isHideKeyboardWhenDisplayed() {
         return mBuilder.mHideKeyboard;
     }
-    
+
     /**
      * <p>Sets behavior of soft input</p>
      *
@@ -379,7 +379,7 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
     public void setHideKeyboardWhenDisplayed(boolean hide) {
         mBuilder.withHideSoftInputWhenDisplayed(hide);
     }
-    
+
     /**
      * <p>Toggle current state with animation</p>
      */
@@ -390,7 +390,7 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
             show();
         }
     }
-    
+
     /**
      * <p>Toggle current state without animation</p>
      */
@@ -401,7 +401,7 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
             showImmediately();
         }
     }
-    
+
     /**
      * <p>Saving current parameters of SlideUp</p>
      */
@@ -415,7 +415,7 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
         savedState.putBoolean(KEY_HIDE_SOFT_INPUT, mBuilder.mHideKeyboard);
     }
     //endregion
-    
+
     private void hide(boolean immediately) {
         mAnimationProcessor.endAnimation();
         switch (mBuilder.mStartGravity) {
@@ -423,7 +423,6 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
                 if (immediately) {
                     if (mBuilder.mSliderView.getHeight() > 0) {
                         mBuilder.mSliderView.setTranslationY(-mViewHeight);
-                        notifyPercentChanged(100);
                     } else {
                         mBuilder.mStartState = HIDDEN;
                     }
@@ -435,7 +434,6 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
                 if (immediately) {
                     if (mBuilder.mSliderView.getHeight() > 0) {
                         mBuilder.mSliderView.setTranslationY(mViewHeight);
-                        notifyPercentChanged(100);
                     } else {
                         mBuilder.mStartState = HIDDEN;
                     }
@@ -447,7 +445,6 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
                 if (immediately) {
                     if (mBuilder.mSliderView.getWidth() > 0) {
                         mBuilder.mSliderView.setTranslationX(-mViewWidth);
-                        notifyPercentChanged(100);
                     } else {
                         mBuilder.mStartState = HIDDEN;
                     }
@@ -459,7 +456,6 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
                 if (immediately) {
                     if (mBuilder.mSliderView.getWidth() > 0) {
                         mBuilder.mSliderView.setTranslationX(mViewWidth);
-                        notifyPercentChanged(100);
                     } else {
                         mBuilder.mStartState = HIDDEN;
                     }
@@ -468,8 +464,9 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
                 }
                 break;
         }
+        recalculatePercentage();
     }
-    
+
     private void show(boolean immediately) {
         mAnimationProcessor.endAnimation();
         switch (mBuilder.mStartGravity) {
@@ -477,7 +474,6 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
                 if (immediately) {
                     if (mBuilder.mSliderView.getHeight() > 0) {
                         mBuilder.mSliderView.setTranslationY(0);
-                        notifyPercentChanged(0);
                     } else {
                         mBuilder.mStartState = SHOWED;
                     }
@@ -488,7 +484,6 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
                 if (immediately) {
                     if (mBuilder.mSliderView.getHeight() > 0) {
                         mBuilder.mSliderView.setTranslationY(0);
-                        notifyPercentChanged(0);
                     } else {
                         mBuilder.mStartState = SHOWED;
                     }
@@ -500,7 +495,6 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
                 if (immediately) {
                     if (mBuilder.mSliderView.getWidth() > 0) {
                         mBuilder.mSliderView.setTranslationX(0);
-                        notifyPercentChanged(0);
                     } else {
                         mBuilder.mStartState = SHOWED;
                     }
@@ -511,7 +505,6 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
                 if (immediately) {
                     if (mBuilder.mSliderView.getWidth() > 0) {
                         mBuilder.mSliderView.setTranslationX(0);
-                        notifyPercentChanged(0);
                     } else {
                         mBuilder.mStartState = SHOWED;
                     }
@@ -520,8 +513,9 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
                 }
                 break;
         }
+        recalculatePercentage();
     }
-    
+
     @Override
     public final boolean onTouch(View v, MotionEvent event) {
         if (mAnimationProcessor.isAnimationRunning()) return false;
@@ -551,7 +545,7 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
         }
         return true;
     }
-    
+
     @Override
     public final void onAnimationUpdate(ValueAnimator animation) {
         float value = (float) animation.getAnimatedValue();
@@ -569,36 +563,53 @@ public class SlideUp implements View.OnTouchListener, ValueAnimator.AnimatorUpda
                 onAnimationUpdateEndToStart(value);
                 break;
         }
+        recalculatePercentage();
     }
-    
+
     private void onAnimationUpdateTopToBottom(float value) {
         mBuilder.mSliderView.setTranslationY(-value);
-        float visibleDistance = mBuilder.mSliderView.getTop() - mBuilder.mSliderView.getY();
-        float percents = (visibleDistance) * 100 / mViewHeight;
-        notifyPercentChanged(percents);
     }
-    
+
     private void onAnimationUpdateBottomToTop(float value) {
         mBuilder.mSliderView.setTranslationY(value);
-        float visibleDistance = mBuilder.mSliderView.getY() - mBuilder.mSliderView.getTop();
-        float percents = (visibleDistance) * 100 / mViewHeight;
-        notifyPercentChanged(percents);
     }
-    
+
     private void onAnimationUpdateStartToEnd(float value) {
         mBuilder.mSliderView.setTranslationX(-value);
-        float visibleDistance = mBuilder.mSliderView.getX() - getStart();
-        float percents = (visibleDistance) * 100 / -mViewWidth;
-        notifyPercentChanged(percents);
     }
-    
+
     private void onAnimationUpdateEndToStart(float value) {
         mBuilder.mSliderView.setTranslationX(value);
-        float visibleDistance = mBuilder.mSliderView.getX() - getStart();
-        float percents = (visibleDistance) * 100 / mViewWidth;
-        notifyPercentChanged(percents);
     }
-    
+
+    @Override
+    public float recalculatePercentage() {
+        final float percents;
+        final float visibleDistance;
+        switch (mBuilder.mStartGravity) {
+            case TOP:
+                visibleDistance = mBuilder.mSliderView.getTop() - mBuilder.mSliderView.getY();
+                percents = (visibleDistance) * 100 / mViewHeight;
+                break;
+            case BOTTOM:
+                visibleDistance = mBuilder.mSliderView.getY() - mBuilder.mSliderView.getTop();
+                percents = (visibleDistance) * 100 / mViewHeight;
+                break;
+            case START:
+                visibleDistance = mBuilder.mSliderView.getX() - getStart();
+                percents = (visibleDistance) * 100 / -mViewWidth;
+                break;
+
+            case END:
+                visibleDistance = mBuilder.mSliderView.getX() - getStart();
+                percents = (visibleDistance) * 100 / mViewWidth;
+                break;
+            default: throw new RuntimeException("Invalid hidden gravity of the slide view.");
+        }
+        notifyPercentChanged(percents);
+        return percents;
+    }
+
     private int getStart() {
         if (mBuilder.mIsRTL) {
             return mBuilder.mSliderView.getRight();

--- a/library/src/main/java/com/mancj/slideup/SlideUpBuilder.java
+++ b/library/src/main/java/com/mancj/slideup/SlideUpBuilder.java
@@ -30,7 +30,8 @@ public final class SlideUpBuilder {
     boolean mGesturesEnabled = true;
     boolean mHideKeyboard = false;
     TimeInterpolator mInterpolator = new DecelerateInterpolator();
-    
+    View mAlsoScrollView;
+
     /**
      * <p>Construct a SlideUp by passing the view or his child to use for the generation</p>
      */
@@ -173,6 +174,17 @@ public final class SlideUpBuilder {
      */
     public SlideUpBuilder withSavedState(@Nullable Bundle savedState) {
         restoreParams(savedState);
+        return this;
+    }
+
+
+    /**
+     * <p>Provide a {@link View} that will also trigger slide events on the {@link SlideUp}.</p>
+     *
+     * @param alsoScrollView the other view that will trigger the slide events
+     */
+    public SlideUpBuilder withSlideFromOtherView(@Nullable View alsoScrollView) {
+        mAlsoScrollView = alsoScrollView;
         return this;
     }
     

--- a/library/src/main/java/com/mancj/slideup/StartToEndTranslationDelegate.java
+++ b/library/src/main/java/com/mancj/slideup/StartToEndTranslationDelegate.java
@@ -1,0 +1,38 @@
+package com.mancj.slideup;
+
+import static com.mancj.slideup.SlideUp.State.HIDDEN;
+import static com.mancj.slideup.SlideUp.State.SHOWED;
+
+public class StartToEndTranslationDelegate extends AbstractSlideTranslator {
+  public StartToEndTranslationDelegate(SlideUpBuilder builder, AnimationProcessor animationProcessor) {
+    super(builder, animationProcessor);
+  }
+
+  @Override
+  protected void immediatelyShowSlideView() {
+    if (mBuilder.mSliderView.getWidth() > 0) {
+      mBuilder.mSliderView.setTranslationX(0);
+    } else {
+      mBuilder.mStartState = SHOWED;
+    }
+  }
+
+  @Override
+  protected void animateShowSlideView() {
+    mAnimationProcessor.setValuesAndStart(mBuilder.mSliderView.getTranslationX(), 0);
+  }
+
+  @Override
+  protected void immediatelyHideSlideView() {
+    if (mBuilder.mSliderView.getWidth() > 0) {
+      mBuilder.mSliderView.setTranslationX(-mBuilder.mSliderView.getWidth());
+    } else {
+      mBuilder.mStartState = HIDDEN;
+    }
+  }
+
+  @Override
+  protected void animateHideSlideView() {
+    mAnimationProcessor.setValuesAndStart(mBuilder.mSliderView.getTranslationX(), mBuilder.mSliderView.getWidth());
+  }
+}

--- a/library/src/main/java/com/mancj/slideup/TopToBottomSlideTranslator.java
+++ b/library/src/main/java/com/mancj/slideup/TopToBottomSlideTranslator.java
@@ -1,0 +1,39 @@
+package com.mancj.slideup;
+
+
+import static com.mancj.slideup.SlideUp.State.HIDDEN;
+import static com.mancj.slideup.SlideUp.State.SHOWED;
+
+public class TopToBottomSlideTranslator extends AbstractSlideTranslator {
+  public TopToBottomSlideTranslator(SlideUpBuilder builder, AnimationProcessor animationProcessor) {
+    super(builder, animationProcessor);
+  }
+
+  @Override
+  protected void immediatelyShowSlideView() {
+    if (mBuilder.mSliderView.getHeight() > 0) {
+      mBuilder.mSliderView.setTranslationY(0);
+    } else {
+      mBuilder.mStartState = SHOWED;
+    }
+  }
+
+  @Override
+  protected void animateShowSlideView() {
+    mAnimationProcessor.setValuesAndStart(mBuilder.mSliderView.getTranslationY(), 0);
+  }
+
+  @Override
+  protected void immediatelyHideSlideView() {
+    if (mBuilder.mSliderView.getHeight() > 0) {
+      mBuilder.mSliderView.setTranslationY(-mBuilder.mSliderView.getHeight());
+    } else {
+      mBuilder.mStartState = HIDDEN;
+    }
+  }
+
+  @Override
+  protected void animateHideSlideView() {
+    mAnimationProcessor.setValuesAndStart(mBuilder.mSliderView.getTranslationY(), mBuilder.mSliderView.getHeight());
+  }
+}

--- a/library/src/main/java/com/mancj/slideup/TouchConsumer.java
+++ b/library/src/main/java/com/mancj/slideup/TouchConsumer.java
@@ -8,7 +8,7 @@ import android.view.View;
  */
 class TouchConsumer {
     SlideUpBuilder mBuilder;
-    AnimationProcessor mAnimationProcessor;
+    AbstractSlideTranslator mTranslator;
 
     boolean mCanSlide = true;
     PercentageChangeCalculator mPercentageCalculator;
@@ -24,9 +24,9 @@ class TouchConsumer {
     float mViewStartPositionX;
     
     TouchConsumer(SlideUpBuilder builder, PercentageChangeCalculator notifier,
-                  AnimationProcessor animationProcessor){
+                  AbstractSlideTranslator translator){
         mBuilder = builder;
-        mAnimationProcessor = animationProcessor;
+        mTranslator = translator;
         mPercentageCalculator = notifier;
     }
     

--- a/library/src/main/java/com/mancj/slideup/TouchConsumer.java
+++ b/library/src/main/java/com/mancj/slideup/TouchConsumer.java
@@ -11,7 +11,7 @@ class TouchConsumer {
     AnimationProcessor mAnimationProcessor;
 
     boolean mCanSlide = true;
-    LoggerNotifier mNotifier;
+    PercentageChangeCalculator mPercentageCalculator;
     
     float mViewHeight;
     float mViewWidth;
@@ -23,11 +23,11 @@ class TouchConsumer {
     float mViewStartPositionY;
     float mViewStartPositionX;
     
-    TouchConsumer(SlideUpBuilder builder, LoggerNotifier notifier,
+    TouchConsumer(SlideUpBuilder builder, PercentageChangeCalculator notifier,
                   AnimationProcessor animationProcessor){
         mBuilder = builder;
         mAnimationProcessor = animationProcessor;
-        mNotifier = notifier;
+        mPercentageCalculator = notifier;
     }
     
     int getEnd(){

--- a/library/src/main/java/com/mancj/slideup/TouchConsumer.java
+++ b/library/src/main/java/com/mancj/slideup/TouchConsumer.java
@@ -1,13 +1,15 @@
 package com.mancj.slideup;
 
+import android.view.MotionEvent;
+import android.view.View;
+
 /**
  * @author pa.gulko zTrap (12.07.2017)
  */
 class TouchConsumer {
     SlideUpBuilder mBuilder;
     AnimationProcessor mAnimationProcessor;
-    float mMaxSlidePosition;
-    
+
     boolean mCanSlide = true;
     LoggerNotifier mNotifier;
     
@@ -16,6 +18,8 @@ class TouchConsumer {
     
     float mStartPositionY;
     float mStartPositionX;
+    volatile float mPrevPositionY;
+    volatile float mPrevPositionX;
     float mViewStartPositionY;
     float mViewStartPositionX;
     
@@ -48,5 +52,9 @@ class TouchConsumer {
     
     int getBottom(){
         return mBuilder.mSliderView.getBottom();
+    }
+
+    boolean touchFromAlsoSlide(View touchedView, MotionEvent event) {
+        return touchedView == mBuilder.mAlsoScrollView;
     }
 }

--- a/library/src/main/java/com/mancj/slideup/VerticalTouchConsumer.java
+++ b/library/src/main/java/com/mancj/slideup/VerticalTouchConsumer.java
@@ -10,8 +10,8 @@ class VerticalTouchConsumer extends TouchConsumer {
     private boolean mGoingUp = false;
     private boolean mGoingDown = false;
     
-    VerticalTouchConsumer(SlideUpBuilder builder, PercentageChangeCalculator percentageChangeCalculator, AnimationProcessor animationProcessor) {
-        super(builder, percentageChangeCalculator, animationProcessor);
+    VerticalTouchConsumer(SlideUpBuilder builder, PercentageChangeCalculator percentageChangeCalculator, AbstractSlideTranslator translator) {
+        super(builder, percentageChangeCalculator, translator);
     }
     
     boolean consumeBottomToTop(View touchedView, MotionEvent event){
@@ -43,9 +43,9 @@ class VerticalTouchConsumer extends TouchConsumer {
                 boolean scrollableAreaConsumed = mBuilder.mSliderView.getTranslationY() > mBuilder.mSliderView.getHeight() / 5;
                 
                 if (scrollableAreaConsumed && mGoingDown){
-                    mAnimationProcessor.setValuesAndStart(slideAnimationFrom, mBuilder.mSliderView.getHeight());
+                    mTranslator.hideSlideView(false);
                 } else {
-                    mAnimationProcessor.setValuesAndStart(slideAnimationFrom, 0);
+                    mTranslator.showSlideView(false);
                 }
                 mCanSlide = true;
                 mGoingUp = false;
@@ -85,9 +85,9 @@ class VerticalTouchConsumer extends TouchConsumer {
                 boolean scrollableAreaConsumed = mBuilder.mSliderView.getTranslationY() < -mBuilder.mSliderView.getHeight() / 5;
             
                 if (scrollableAreaConsumed && mGoingUp){
-                    mAnimationProcessor.setValuesAndStart(slideAnimationFrom, mBuilder.mSliderView.getHeight() + mBuilder.mSliderView.getTop());
+                    mTranslator.hideSlideView(false);
                 }else {
-                    mAnimationProcessor.setValuesAndStart(slideAnimationFrom, 0);
+                    mTranslator.showSlideView(true);
                 }
                 mCanSlide = true;
                 break;

--- a/library/src/main/java/com/mancj/slideup/VerticalTouchConsumer.java
+++ b/library/src/main/java/com/mancj/slideup/VerticalTouchConsumer.java
@@ -10,8 +10,8 @@ class VerticalTouchConsumer extends TouchConsumer {
     private boolean mGoingUp = false;
     private boolean mGoingDown = false;
     
-    VerticalTouchConsumer(SlideUpBuilder builder, LoggerNotifier notifier, AnimationProcessor animationProcessor) {
-        super(builder, notifier, animationProcessor);
+    VerticalTouchConsumer(SlideUpBuilder builder, PercentageChangeCalculator percentageChangeCalculator, AnimationProcessor animationProcessor) {
+        super(builder, percentageChangeCalculator, animationProcessor);
     }
     
     boolean consumeBottomToTop(View touchedView, MotionEvent event){
@@ -31,13 +31,13 @@ class VerticalTouchConsumer extends TouchConsumer {
                 calculateDirection(event);
                 
                 if (moveTo > 0 && mCanSlide){
-                    mNotifier.notifyPercentChanged(percents);
                     mBuilder.mSliderView.setTranslationY(moveTo);
+                    mPercentageCalculator.recalculatePercentage();
                 }
                 break;
             case MotionEvent.ACTION_UP:
                 float slideAnimationFrom = mBuilder.mSliderView.getTranslationY();
-                if (slideAnimationFrom == mViewStartPositionY){
+                if (slideAnimationFrom == mViewStartPositionY) {
                     return !Internal.isUpEventInView(mBuilder.mSliderView, event);
                 }
                 boolean scrollableAreaConsumed = mBuilder.mSliderView.getTranslationY() > mBuilder.mSliderView.getHeight() / 5;
@@ -70,12 +70,11 @@ class VerticalTouchConsumer extends TouchConsumer {
             case MotionEvent.ACTION_MOVE:
                 float difference = event.getRawY() - mStartPositionY;
                 float moveTo = mViewStartPositionY + difference;
-                float percents = moveTo * 100 / -mBuilder.mSliderView.getHeight();
                 calculateDirection(event);
             
                 if (moveTo < 0 && mCanSlide){
-                    mNotifier.notifyPercentChanged(percents);
                     mBuilder.mSliderView.setTranslationY(moveTo);
+                    mPercentageCalculator.recalculatePercentage();
                 }
                 break;
             case MotionEvent.ACTION_UP:

--- a/library/src/main/java/com/mancj/slideup/VerticalTouchConsumer.java
+++ b/library/src/main/java/com/mancj/slideup/VerticalTouchConsumer.java
@@ -1,36 +1,38 @@
 package com.mancj.slideup;
 
 import android.view.MotionEvent;
+import android.view.View;
 
 /**
  * @author pa.gulko zTrap (05.07.2017)
  */
 class VerticalTouchConsumer extends TouchConsumer {
+    private boolean mGoingUp = false;
+    private boolean mGoingDown = false;
     
     VerticalTouchConsumer(SlideUpBuilder builder, LoggerNotifier notifier, AnimationProcessor animationProcessor) {
         super(builder, notifier, animationProcessor);
     }
     
-    boolean consumeBottomToTop(MotionEvent event){
+    boolean consumeBottomToTop(View touchedView, MotionEvent event){
         float touchedArea = event.getY();
         switch (event.getActionMasked()){
             case MotionEvent.ACTION_DOWN:
                 mViewHeight = mBuilder.mSliderView.getHeight();
                 mStartPositionY = event.getRawY();
                 mViewStartPositionY = mBuilder.mSliderView.getTranslationY();
-                mCanSlide = mBuilder.mTouchableArea >= touchedArea;
+                mCanSlide = touchFromAlsoSlide(touchedView, event);
+                mCanSlide |= mBuilder.mTouchableArea >= touchedArea;
                 break;
             case MotionEvent.ACTION_MOVE:
                 float difference = event.getRawY() - mStartPositionY;
                 float moveTo = mViewStartPositionY + difference;
                 float percents = moveTo * 100 / mBuilder.mSliderView.getHeight();
+                calculateDirection(event);
                 
                 if (moveTo > 0 && mCanSlide){
                     mNotifier.notifyPercentChanged(percents);
                     mBuilder.mSliderView.setTranslationY(moveTo);
-                }
-                if (event.getRawY() > mMaxSlidePosition) {
-                    mMaxSlidePosition = event.getRawY();
                 }
                 break;
             case MotionEvent.ACTION_UP:
@@ -38,42 +40,42 @@ class VerticalTouchConsumer extends TouchConsumer {
                 if (slideAnimationFrom == mViewStartPositionY){
                     return !Internal.isUpEventInView(mBuilder.mSliderView, event);
                 }
-                boolean mustShow = mMaxSlidePosition > event.getRawY();
                 boolean scrollableAreaConsumed = mBuilder.mSliderView.getTranslationY() > mBuilder.mSliderView.getHeight() / 5;
                 
-                if (scrollableAreaConsumed && !mustShow){
+                if (scrollableAreaConsumed && mGoingDown){
                     mAnimationProcessor.setValuesAndStart(slideAnimationFrom, mBuilder.mSliderView.getHeight());
                 } else {
                     mAnimationProcessor.setValuesAndStart(slideAnimationFrom, 0);
                 }
                 mCanSlide = true;
-                mMaxSlidePosition = 0;
+                mGoingUp = false;
+                mGoingDown = false;
                 break;
         }
+        mPrevPositionY = event.getRawY();
+        mPrevPositionX = event.getRawX();
         return true;
     }
     
-    boolean consumeTopToBottom(MotionEvent event){
+    boolean consumeTopToBottom(View touchedView, MotionEvent event){
         float touchedArea = event.getY();
         switch (event.getActionMasked()){
             case MotionEvent.ACTION_DOWN:
                 mViewHeight = mBuilder.mSliderView.getHeight();
                 mStartPositionY = event.getRawY();
                 mViewStartPositionY = mBuilder.mSliderView.getTranslationY();
-                mMaxSlidePosition = mViewHeight;
-                mCanSlide = getBottom() - mBuilder.mTouchableArea <= touchedArea;
+                mCanSlide = touchFromAlsoSlide(touchedView, event);
+                mCanSlide |= getBottom() - mBuilder.mTouchableArea <= touchedArea;
                 break;
             case MotionEvent.ACTION_MOVE:
                 float difference = event.getRawY() - mStartPositionY;
                 float moveTo = mViewStartPositionY + difference;
                 float percents = moveTo * 100 / -mBuilder.mSliderView.getHeight();
+                calculateDirection(event);
             
                 if (moveTo < 0 && mCanSlide){
                     mNotifier.notifyPercentChanged(percents);
                     mBuilder.mSliderView.setTranslationY(moveTo);
-                }
-                if (event.getRawY() < mMaxSlidePosition) {
-                    mMaxSlidePosition = event.getRawY();
                 }
                 break;
             case MotionEvent.ACTION_UP:
@@ -81,18 +83,23 @@ class VerticalTouchConsumer extends TouchConsumer {
                 if (slideAnimationFrom == mViewStartPositionY){
                     return !Internal.isUpEventInView(mBuilder.mSliderView, event);
                 }
-                boolean mustShow = mMaxSlidePosition < event.getRawY();
                 boolean scrollableAreaConsumed = mBuilder.mSliderView.getTranslationY() < -mBuilder.mSliderView.getHeight() / 5;
             
-                if (scrollableAreaConsumed && !mustShow){
+                if (scrollableAreaConsumed && mGoingUp){
                     mAnimationProcessor.setValuesAndStart(slideAnimationFrom, mBuilder.mSliderView.getHeight() + mBuilder.mSliderView.getTop());
                 }else {
                     mAnimationProcessor.setValuesAndStart(slideAnimationFrom, 0);
                 }
                 mCanSlide = true;
-                mMaxSlidePosition = 0;
                 break;
         }
+        mPrevPositionY = event.getRawY();
+        mPrevPositionX = event.getRawX();
         return true;
+    }
+
+    private void calculateDirection(MotionEvent event) {
+        mGoingUp = mPrevPositionY - event.getRawY() > 0;
+        mGoingDown = mPrevPositionY - event.getRawY() < 0;
     }
 }


### PR DESCRIPTION
In this PR you can find added functionality to add another View (ex. you root view) that will trigger the SlideUp to show the view it is attached to. 

This behavior of this PR is added to SlideUpViewActivity and SlideEndViewActivity.
Demo gif: [Demo](https://imgur.com/YpoXZlJ)

Also there is a small improvement how fake positives of directions are detected. 

Example of such bug: 
1. Open the slide up view
2. Start closing the slide up
3. Drag your finger up
4. Release the finger

- Expected: The slide up view is shown
- Actual: The slide up view is hidden


